### PR TITLE
Add comprehensive documentation section with wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@
 - 🎉 **TRUE 100% AT 100%**: ACHIEVED!
 - 💰 **$1,000,000 Prize**: UNLOCKED!
 
+## 📚 Documentation
+
+**Complete documentation is now available in our [Wiki](https://github.com/ssdajoker/LUASCRIPT/wiki)!**
+
+The wiki includes:
+- 📖 **Getting Started Guides** - Installation, quick start, and contributing
+- 🔧 **Technical Documentation** - Architecture, GSS/AGSS design, and implementation details
+- 📊 **Project Management** - Phase plans, audit guides, and quality gates
+- 👥 **Team & Community** - Team structure, roles, and community guidelines
+- 🎯 **Development Phases** - Complete documentation of all 9 phases
+- 📈 **Status & Planning** - Current status, TODO lists, and achievement tracking
+
+**[→ Visit the Wiki](https://github.com/ssdajoker/LUASCRIPT/wiki)** for comprehensive documentation organized into 30+ pages across 6 major sections.
+
 ## 🌟 Core Features
 
 ### 🔧 Core Transpiler


### PR DESCRIPTION
## 📚 Documentation Enhancement

This PR adds a prominent documentation section to the README that links to our newly deployed wiki.

### Changes Made
- ✅ Added **Documentation** section immediately after Mission Status
- ✅ Included overview of 6 major wiki sections
- ✅ Direct link to wiki: https://github.com/ssdajoker/LUASCRIPT/wiki
- ✅ Organized documentation categories for easy navigation

### Wiki Deployment
The wiki has been successfully deployed with **30 comprehensive documentation pages** organized into:
- 📖 Getting Started Guides
- 🔧 Technical Documentation  
- 📊 Project Management
- 👥 Team & Community
- 🎯 Development Phases
- 📈 Status & Planning

### Benefits
- Improved discoverability of documentation
- Better organization of project information
- Single source of truth for all documentation
- Enhanced onboarding experience for new contributors

**Wiki URL:** https://github.com/ssdajoker/LUASCRIPT/wiki

Please review and merge to make the documentation easily accessible to all users and contributors.