### PR TITLE
Normalize transpile options for parser tests

### DIFF
--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -130,7 +130,7 @@ class LuaScriptTranspiler {
                     duration,
                     optimizations: 0,
                     originalSize: jsCode.length,
-                    filename: normalizedOptions && normalizedOptions.filename ? normalizedOptions.filename : null,
+                    filename: normalizedOptions.filename || null,
                 },
             };
 


### PR DESCRIPTION
## Summary
- normalize LuaScriptTranspiler option handling so legacy string filenames are accepted
- ensure runtime injection, validation, and stats reporting use the normalized options

## Testing
- node - <<'NODE' ... (legacy options)
- node - <<'NODE' ... (canonical pipeline)
- npm run test:legacy:parser *(fails: SyntaxError in src/core_transpiler.js)*

------
https://chatgpt.com/codex/tasks/task_e_68fc5704ddec832b85c4e8b1562dfd8a