### PR TITLE
Fix splitTopLevel unmatched closing delimiter handling

### DIFF
--- a/src/runtime_system.js
+++ b/src/runtime_system.js
@@ -850,12 +850,16 @@ class LuaInterpreter {
 
             if (char === ')' || char === '}' || char === ']') {
                 if (stack.length === 0) {
-                    throw new Error(pushError(`Unmatched closing delimiter '${char}' at position ${i}`));
+                    const msg = `Unmatched closing delimiter '${char}' at position ${i}`;
+                    pushError(msg);
+                    throw new Error(msg);
                 }
 
                 const expected = stack.pop();
                 if (char !== expected) {
-                    throw new Error(pushError(`Mismatched closing delimiter: expected '${expected}', got '${char}' at position ${i}`));
+                    const msg = `Mismatched closing delimiter: expected '${expected}', got '${char}' at position ${i}`;
+                    pushError(msg);
+                    throw new Error(msg);
                 }
 
                 current += char;


### PR DESCRIPTION
## Summary
- clean up duplicate splitTopLevel implementation in the runtime system
- ensure unmatched and mismatched closing delimiters throw explicit errors while tracking them in runtime stats
- improve delimiter validation by reusing a helper for error reporting and keeping quote state checks consistent

## Testing
- npm test (fails: existing SyntaxError in src/core_transpiler.js template string parsing)


------
https://chatgpt.com/codex/tasks/task_e_68fc57a13988832b8a896a5257f890a3