### PR TITLE
Reorder array guard in transpile option normalization

### DIFF
--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -168,11 +168,11 @@ class LuaScriptTranspiler {
             return { filename: options };
         }
 
-        if (typeof options !== 'object') {
+        if (Array.isArray(options)) {
             return {};
         }
 
-        if (Array.isArray(options)) {
+        if (typeof options !== 'object') {
             return {};
         }
 


### PR DESCRIPTION
## Summary
- ensure `normalizeTranspileOptions` returns early for arrays before the generic object type guard

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fc59a26790832ba8a67554d5f9d177