### PR TITLE
Prevent zero step in range iteration

### DIFF
--- a/runtime/core/enhanced_runtime.lua
+++ b/runtime/core/enhanced_runtime.lua
@@ -352,6 +352,9 @@ local function normalize_step(start_value, end_value, step)
 end
 
 local function iterate_range(start_value, end_value, step, handler)
+    if step == 0 then
+        error("math range step cannot be zero")
+    end
     local index = 0
     for value = start_value, end_value, step do
         handler(value, index)

--- a/runtime/runtime.lua
+++ b/runtime/runtime.lua
@@ -486,6 +486,9 @@ local function normalize_step(start_value, end_value, step)
 end
 
 local function iterate_range(start_value, end_value, step, handler)
+    if step == 0 then
+        error("math range step cannot be zero")
+    end
     local index = 0
     for value = start_value, end_value, step do
         handler(value, index)


### PR DESCRIPTION
## Summary
- add explicit validation in the range iterators to prevent a zero step value that would hang Lua for-loops

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fc5b4413c8832b8330f17d6c7a4ee3