### PR TITLE
Guard callback-first summation against falsy terms

### DIFF
--- a/runtime/core/enhanced_runtime.lua
+++ b/runtime/core/enhanced_runtime.lua
@@ -380,6 +380,33 @@ local function summation_impl(collection_or_start, finish, step_or_mapper, maybe
             end
         end
         return total
+    elseif type(collection_or_start) == "function" then
+        local mapper = collection_or_start
+        if type(finish) ~= "number" or type(step_or_mapper) ~= "number" then
+            error("math.summation expects numeric bounds when callback is first argument")
+        end
+
+        local lower = ensure_numeric(finish, "math.summation lower")
+        local upper = ensure_numeric(step_or_mapper, "math.summation upper")
+        local step
+
+        if maybe_mapper ~= nil then
+            if type(maybe_mapper) ~= "number" then
+                error("math.summation step must be a number")
+            end
+            step = normalize_step(lower, upper, ensure_numeric(maybe_mapper, "math.summation step"))
+        else
+            step = normalize_step(lower, upper)
+        end
+
+        iterate_range(lower, upper, step, function(value, index)
+            local mapped = mapper(value, index)
+            if mapped then
+                total = total + mapped
+            end
+        end)
+
+        return total
     elseif type(collection_or_start) == "number" and type(finish) == "number" then
         local step, mapper
         if type(step_or_mapper) == "number" then

--- a/runtime/runtime.lua
+++ b/runtime/runtime.lua
@@ -514,6 +514,33 @@ local function summation_impl(collection_or_start, finish, step_or_mapper, maybe
             end
         end
         return total
+    elseif type(collection_or_start) == "function" then
+        local mapper = collection_or_start
+        if type(finish) ~= "number" or type(step_or_mapper) ~= "number" then
+            error("math.summation expects numeric bounds when callback is first argument")
+        end
+
+        local lower = ensure_numeric(finish, "math.summation lower")
+        local upper = ensure_numeric(step_or_mapper, "math.summation upper")
+        local step
+
+        if maybe_mapper ~= nil then
+            if type(maybe_mapper) ~= "number" then
+                error("math.summation step must be a number")
+            end
+            step = normalize_step(lower, upper, ensure_numeric(maybe_mapper, "math.summation step"))
+        else
+            step = normalize_step(lower, upper)
+        end
+
+        iterate_range(lower, upper, step, function(value, index)
+            local mapped = mapper(value, index)
+            if mapped then
+                total = total + mapped
+            end
+        end)
+
+        return total
     elseif type(collection_or_start) == "number" and type(finish) == "number" then
         local step, mapper
         if type(step_or_mapper) == "number" then


### PR DESCRIPTION
## Summary
- add a callback-first branch to summation_impl that accepts numeric bounds
- skip falsy callback results so boolean filters do not cause arithmetic errors
- mirror the same behavior in the base runtime implementation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fce07f3368832bb1a1e7266c44b71e