### PR TITLE
Add GitHub App dynamic auth workflow

### DIFF
--- a/actions/github_app_dynamic.yml
+++ b/actions/github_app_dynamic.yml
@@ -1,0 +1,25 @@
+name: GitHub App Dynamic Auth
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Operation mode (review/rescue/yolo)"
+        required: true
+        default: "review"
+
+jobs:
+  auth:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate short-lived token
+        id: token
+        uses: actions/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+
+      - name: Print mode & token (safe subset)
+        run: |
+          echo "Mode: ${{ github.event.inputs.mode }}"
+          echo "Token starts with: $(echo ${{ steps.token.outputs.token }} | cut -c1-6)..."


### PR DESCRIPTION
### Motivation
- Provide a reusable GitHub Actions workflow that generates a short-lived GitHub App installation token for use in CI steps.
- Allow the workflow to be invoked manually with an operation `mode` input to control behavior (`review`, `rescue`, `yolo`).
- Avoid leaking full tokens by only echoing a safe subset for debugging.

### Description
- Added a new workflow file at `actions/github_app_dynamic.yml` that is triggered via `workflow_dispatch` with a `mode` input.
- The workflow defines a single job `auth` that runs on `ubuntu-latest` and uses the `actions/github-app-token@v1` action to generate a token with `app_id`, `private_key`, and `installation_id` taken from repository secrets.
- After token generation the workflow prints the `mode` and a truncated prefix of the token for safe visibility.
- The change creates and commits the new workflow file into the repository.

### Testing
- No automated tests were run as this is a workflow-only change and requires GitHub Actions runtime to execute.
- The new file was committed successfully to the repository; no CI execution was performed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f19bc8778832bb840186f58bb7e0e)